### PR TITLE
Fix:"Error: Cannot Handle Data Type: (1, 1, 3), <f4"

### DIFF
--- a/render_360.py
+++ b/render_360.py
@@ -77,6 +77,9 @@ def main_canonical_360(opt):
         save_path = os.path.join('./demo', f'canonical_360/{os.path.basename(opt.scene_dir)}', f'out_{str(i).zfill(4)}.png')
         if not os.path.isdir(os.path.dirname(save_path)):
             os.makedirs(os.path.dirname(save_path))
+        # Convert the output image array to a valid data type (e.g., uint8) and reshape if necessary
+        out = np.clip(out * 255, 0, 255).astype(np.uint8)
+        out = np.squeeze(out)  # Remove singleton dimensions if present
         imageio.imsave(save_path, out)
         print(f'image saved: {save_path}')
 
@@ -125,6 +128,9 @@ def main_posed_360(opt):
         save_path = os.path.join('./demo', f'posed_360/{os.path.basename(opt.scene_dir)}', f'out_{str(i).zfill(4)}.png')
         if not os.path.isdir(os.path.dirname(save_path)):
             os.makedirs(os.path.dirname(save_path))
+        # Convert the output image array to a valid data type (e.g., uint8) and reshape if necessary
+        out = np.clip(out * 255, 0, 255).astype(np.uint8)
+        out = np.squeeze(out)  # Remove singleton dimensions if present
         imageio.imsave(save_path, out)
         print(f'image saved: {save_path}')
 


### PR DESCRIPTION
This pull request addresses an error #79 that occurs when attempting to handle a specific data type: (1, 1, 3), <f4. The error is triggered while using the `PIL` library's `Image.fromarray` function, resulting in a `KeyError` exception. The pull request aims to resolve this issue by implementing a fix that allows the code to handle the mentioned data type properly. The fix ensures that the `fromarray` function can process the data without throwing any exceptions, enabling successful execution and preventing the traceback mentioned in the error message.
